### PR TITLE
[ADD]회원가입페이지

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,40 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    <meta name="description" content="preOnBoarding 과제" />
     <title>React App</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,14 @@
 import React from 'react'
-import { Route, Routes, BrowserRouter, Navigate } from 'react-router-dom'
+import { Route, Routes, BrowserRouter } from 'react-router-dom'
 import Auth from './pages/Auth'
 import Todo from './pages/Todo'
 
-import { getToken } from './utils/auth'
 function App() {
-  const accessToken = getToken()
-
   return (
     <BrowserRouter>
       <Routes>
-        <Route index element={accessToken ? <Navigate to="/todo" replace /> : <Auth />} />
-        <Route path="/todo" element={!accessToken ? <Navigate to="/" replace /> : <Todo />} />
+        <Route index element={<Auth />} />
+        <Route path="/todo" element={<Todo />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,32 @@
+import axios from 'axios'
+import { getToken } from '../utils/token.js'
+
+const baseURL = 'https://n38lcff1wk.execute-api.ap-northeast-2.amazonaws.com'
+
+let token
+if (getToken()) {
+  // token = getToken().replace(/\"/gi, '')
+}
+
+export const tokenAxios = axios.create({
+  baseURL: baseURL,
+  headers: {
+    Authorization: `Bearer ${token}`,
+  },
+})
+
+export const Axios = axios.create({
+  baseURL: baseURL,
+  headers: {
+    'Content-type': 'application/json',
+  },
+})
+
+// createTodo, updateTodo
+export const todoAxios = axios.create({
+  baseURL: baseURL,
+  headers: {
+    'Content-type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  },
+})

--- a/src/components/signIn/SignIn.jsx
+++ b/src/components/signIn/SignIn.jsx
@@ -1,0 +1,95 @@
+import React, { useCallback, useState } from 'react'
+import { setToken } from '../../utils/token'
+import { signIn } from '../../utils/auth'
+import * as S from '../../styles/Auth.style'
+
+function SignIn({ setIsLogin }) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const [emailMessage, setEmailMessage] = useState('')
+  const [passwordMessage, setPasswordMessage] = useState('')
+
+  const [isEmail, setIsEmail] = useState(false)
+  const [isPassword, setIsPassword] = useState(false)
+
+  const onSubmit = async e => {
+    e.preventDefault()
+    const data = JSON.stringify({ email: email, password: password })
+
+    signIn(data)
+      .then(res => {
+        if (res.status === 200) {
+          const {
+            data: { access_token: accessToken },
+          } = res
+          setToken(JSON.stringify(accessToken))
+          window.location.reload()
+        }
+      })
+      .catch(res => {
+        if (res.response.status === 404) {
+          alert('입력 정보가 틀렸습니다')
+        } else if (res.response.status === 401) {
+          alert('비밀번호가 틀렸습니다.')
+        }
+      })
+  }
+
+  const onChangeEmail = useCallback(e => {
+    setEmail(e.target.value)
+    if (e.target.value.includes('@')) {
+      setEmailMessage('이메일 형식이 틀렸어요! 다시 확인해주세요ㅠ')
+      setIsEmail(false)
+    } else {
+      setEmailMessage('올바른 이메일 형식이에요')
+      setIsEmail(true)
+    }
+  }, [])
+
+  const onChangePassword = useCallback(e => {
+    setPassword(e.target.value)
+    if (e.target.value.length < 8) {
+      setIsPassword(false)
+      setPasswordMessage('비밀번호를 8자 이상 입력해주세요!')
+    } else {
+      setIsPassword(true)
+      setPasswordMessage('안전한 비밀번호에요')
+    }
+  }, [])
+
+  return (
+    <S.AuthContainer>
+      <S.AuthTitle>로그인</S.AuthTitle>
+      <S.AuthForm onSubmit={onSubmit}>
+        <S.AuthFieldSet>
+          <S.AuthLabel htmlFor="email">이메일</S.AuthLabel>
+          <S.AuthInput id="email" type="email" name="email" onChange={onChangeEmail} />
+          {email.length > 0 && (
+            <S.AuthMessage className={`message ${isEmail ? 'success' : 'fail'}`}>
+              {emailMessage}
+            </S.AuthMessage>
+          )}
+        </S.AuthFieldSet>
+        <S.AuthFieldSet>
+          <S.AuthLabel htmlFor="password">비밀번호</S.AuthLabel>
+          <S.AuthInput id="password" type="password" name="password" onChange={onChangePassword} />
+          {password.length > 0 && (
+            <S.AuthMessage className={`message ${isPassword ? 'success' : 'fail'}`}>
+              {passwordMessage}
+            </S.AuthMessage>
+          )}
+        </S.AuthFieldSet>
+        <S.AuthButton type="submit" disabled={!isEmail || !isPassword}>
+          로그인
+        </S.AuthButton>
+      </S.AuthForm>
+      <S.AuthFormMessage>
+        계정이 아직 없으신가요?
+        <S.AuthToggle onClick={() => setIsLogin(false)}>회원가입</S.AuthToggle>
+      </S.AuthFormMessage>
+    </S.AuthContainer>
+  )
+}
+
+export default SignIn

--- a/src/components/signUp/SignUp.jsx
+++ b/src/components/signUp/SignUp.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useMemo } from 'react'
+import { signUp } from '../../utils/auth'
+import { useNavigate } from 'react-router-dom'
+import * as S from '../../styles/Auth.style'
+
+function SignUp({ setIsLogin }) {
+  const navigate = useNavigate()
+
+  const [userInfo, setUserInfo] = useState({ email: '', password: '' })
+  const [passwordConfirm, setPasswordConfirm] = useState('')
+
+  const isEmailValid = useMemo(() => {
+    return userInfo.email.includes('@')
+  }, [userInfo.email])
+
+  const isPasswordValid = useMemo(() => {
+    return userInfo.password.length >= 8
+  }, [userInfo.password])
+
+  const isPasswordConfirmValid = useMemo(() => {
+    return passwordConfirm === userInfo.password
+  }, [passwordConfirm, userInfo.password])
+
+  const onSubmit = async e => {
+    e.preventDefault()
+    const data = JSON.stringify(userInfo)
+    signUp(data)
+      .then(res => {
+        if (res.status === 201) {
+          navigate('/')
+        }
+      })
+      .catch(res => {
+        if (res.response.status === 400) {
+          alert('이미 사용자가 있습니다. 다른 정보를 입력해주세요!')
+        }
+      })
+  }
+
+  const onChangeEmail = ({ target }) => {
+    setUserInfo(prev => ({ ...prev, email: target.value }))
+  }
+
+  const onChangePassword = ({ target }) => {
+    setUserInfo(prev => ({ ...prev, password: target.value }))
+  }
+
+  const onChangePasswordConfirm = ({ target }) => {
+    setPasswordConfirm(target.value)
+  }
+
+  return (
+    <S.AuthContainer>
+      <S.AuthTitle>회원가입</S.AuthTitle>
+      <S.AuthForm onSubmit={onSubmit}>
+        <S.AuthFieldSet>
+          <S.AuthLabel htmlFor="email">이메일</S.AuthLabel>
+          <S.AuthInput type="text" name="email" onChange={onChangeEmail} />
+          {userInfo.email.length > 0 && (
+            <S.AuthMessage isValid={isEmailValid}>
+              {isEmailValid
+                ? '올바른 이메일 형식이에요'
+                : '이메일 형식이 틀렸어요! 다시 확인해주세요ㅠ'}
+            </S.AuthMessage>
+          )}
+        </S.AuthFieldSet>
+        <S.AuthFieldSet>
+          <S.AuthLabel htmlFor="password">비밀번호</S.AuthLabel>
+          <S.AuthInput type="password" name="password" onChange={onChangePassword} />
+          {userInfo.password.length > 0 && (
+            <S.AuthMessage isValid={isPasswordValid}>
+              {isPasswordValid ? '안전한 비밀번호에요' : '비밀번호를 8자 이상 입력해주세요!'}
+            </S.AuthMessage>
+          )}
+        </S.AuthFieldSet>
+        <S.AuthFieldSet>
+          <S.AuthLabel htmlFor="passwordConfirm">비밀번호 확인</S.AuthLabel>
+          <S.AuthInput type="password" name="passwordConfirm" onChange={onChangePasswordConfirm} />
+          {passwordConfirm.length > 0 && (
+            <S.AuthMessage isValid={isPasswordConfirmValid}>
+              {isPasswordConfirmValid ? '비밀번호가 일치합니다' : '비밀번호가 일치하지 않습니다'}
+            </S.AuthMessage>
+          )}
+        </S.AuthFieldSet>
+        <S.AuthButton
+          type="submit"
+          disabled={!(isEmailValid && isPasswordValid && isPasswordConfirmValid)}
+        >
+          회원가입
+        </S.AuthButton>
+      </S.AuthForm>
+      <S.AuthFormMessage>
+        이미 가입하셨나요? <S.AuthToggle onClick={() => setIsLogin(true)}>로그인</S.AuthToggle>
+      </S.AuthFormMessage>
+    </S.AuthContainer>
+  )
+}
+
+export default SignUp

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-
 import App from './App'
 
 const root = ReactDOM.createRoot(document.getElementById('root'))

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
+import SignUp from '../components/signUp/SignUp'
+import SignIn from '../components/signIn/SignIn'
 
 const Auth = () => {
-  return <div>Auth</div>
+  const [isLogin, setIsLogin] = useState(true)
+  return isLogin ? <SignIn setIsLogin={setIsLogin} /> : <SignUp setIsLogin={setIsLogin} />
 }
-
 export default Auth

--- a/src/styles/Auth.style.js
+++ b/src/styles/Auth.style.js
@@ -1,0 +1,86 @@
+import styled, { css } from 'styled-components'
+
+export const AuthContainer = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 450px;
+  padding: 40px;
+  transform: translate(-50%, -50%);
+  background-color: azure;
+  box-shadow: 0 15px 25px rgba(0, 0, 0, 0.6);
+  border-radius: 10px;
+`
+
+export const AuthTitle = styled.h1`
+  margin: 0 0 30px;
+  padding: 0;
+  text-align: center;
+`
+
+export const AuthForm = styled.form``
+
+export const AuthFieldSet = styled.fieldset`
+  position: relative;
+  border: none;
+`
+
+export const AuthLabel = styled.label``
+
+export const AuthInput = styled.input`
+  width: 100%;
+  padding: 10px 0;
+  font-size: 16px;
+  margin-bottom: 30px;
+  background: transparent;
+  outline: none;
+  border: none;
+  border-bottom: 1px solid black;
+`
+
+export const AuthMessage = styled.div`
+  position: absolute;
+  bottom: -1px;
+  letter-spacing: -1px;
+  line-height: 24px;
+  color: ${({ isValid }) => (isValid ? 'green' : '#ff2727')};
+`
+
+export const AuthButton = styled.button`
+  position: relative;
+  display: block;
+  margin: 0 auto;
+  padding: 10px 20px;
+  color: #fff;
+  border-radius: 5px;
+  font-size: 16px;
+  margin-top: 10px;
+  transition: all 0.3s;
+  ${({ disabled }) => {
+    if (disabled) {
+      return css`
+        background-color: grey;
+      `
+    } else {
+      return css`
+        background-color: blue;
+        &:hover {
+          background: #03e9f4;
+          color: #fff;
+          border-radius: 5px;
+          box-shadow: 0 0 5px #03e9f4, 0 0 25px #03e9f4, 0 0 50px #03e9f4, 0 0 100px #03e9f4;
+        }
+      `
+    }
+  }};
+`
+
+export const AuthFormMessage = styled.p`
+  text-align: center;
+`
+
+export const AuthToggle = styled.span`
+  text-align: center;
+  color: blueviolet;
+  cursor: pointer;
+`

--- a/src/styles/global.js
+++ b/src/styles/global.js
@@ -1,0 +1,25 @@
+import { createGlobalStyle } from 'styled-components'
+
+const GlobalStyle = createGlobalStyle`
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+  input {
+    user-select:auto;
+  }
+  input:focus {
+    outline: none;
+  }
+  button {
+    border: none;
+    background: none;
+    padding: 0;
+    cursor: pointer;
+  }
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+`
+
+export default GlobalStyle

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,9 @@
+import { Axios } from '../api'
+
+export const signIn = async data => {
+  return await Axios.post('/auth/signin', data)
+}
+
+export const signUp = async data => {
+  return await Axios.post('/auth/signup', data)
+}


### PR DESCRIPTION
### 구현사항
기존 페이지의 Auth.jsx 파일에서 login 페이지의 유무를 boolean으로 판별하여 SignIn 페이지 또는 SignUP 페이지를 나타내도록 하였습니다.

회원가입시 필요한 email, password 를 userInfo 라는 state로 관리하도록 하고, passwordconfirm 은 따로 state로 관리하여
추후 password와 일치하는지를 확인하여 유효성 검사를 실시하였습니다.

유효성 검사는 useMemo 훅을 이용하여 email, password 검사 및 password, passwordConfirm 이 일치하는지 판별하여 유효성검사를 판별하도록 하였습니다.

모든태그를 styled-component를 적용하였으며, 버튼은 disable 상태를 알아보기 유용하도록 disable이 true,false 에 따라 배경색이 바뀌도록 설정하였습니다.

### 변경해야할 부분

변수명을 좀 더 알아보기 쉽도록 변경하면 더 좋을거 같습니다.

추후 SignIn 페이지와 SignUp 페이지가 레이아웃이 크게 다르지 않기에 컴포넌트 재활용을 통해 구현해보면 좋을거 같습니다.